### PR TITLE
fix(contact): reCAPTCHA Enterprise verification + social links layout

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -34,20 +34,27 @@ function checkRateLimit(ip: string): { allowed: boolean; retryAfterSec: number }
   return { allowed: true, retryAfterSec: 0 };
 }
 
-async function verifyRecaptcha(token: string): Promise<boolean> {
-  const secret = process.env.RECAPTCHA_SITE_SECRET;
+// reCAPTCHA Enterprise assessment. Project id is taken from the Google Cloud
+// console (public, non-secret); only the API key lives in the environment.
+const RECAPTCHA_PROJECT = 'personal-website-1783424992246';
+const RECAPTCHA_ACTION = 'submit';
 
-  const params = new URLSearchParams({
-    secret: secret || '',
-    response: token,
-  }).toString();
+async function verifyRecaptcha(token: string): Promise<boolean> {
+  const apiKey = process.env.RECAPTCHA_ENTERPRISE_API_KEY;
+  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+
+  if (!apiKey || !siteKey) {
+    throw new Error('reCAPTCHA Enterprise is not configured');
+  }
 
   const response = await fetch(
-    'https://www.google.com/recaptcha/api/siteverify',
+    `https://recaptchaenterprise.googleapis.com/v1/projects/${RECAPTCHA_PROJECT}/assessments?key=${apiKey}`,
     {
       method: 'POST',
-      body: params,
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        event: { token, expectedAction: RECAPTCHA_ACTION, siteKey },
+      }),
     }
   );
 
@@ -59,7 +66,11 @@ async function verifyRecaptcha(token: string): Promise<boolean> {
 
   const data = await response.json();
 
-  return data.success && data.score >= 0.5;
+  return (
+    data.tokenProperties?.valid === true &&
+    data.tokenProperties?.action === RECAPTCHA_ACTION &&
+    (data.riskAnalysis?.score ?? 0) >= 0.5
+  );
 }
 
 const sendContactEmail = async (formValues: FormValues) => {

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { FormSubmission, FormValues } from '@/types';
 import xss from 'xss';
 import nodemailer from 'nodemailer';
+import { RECAPTCHA_ACTION } from '@/constants/recaptcha';
 
 // nodemailer needs the Node.js runtime; it cannot run on the edge.
 export const runtime = 'nodejs';
@@ -37,7 +38,6 @@ function checkRateLimit(ip: string): { allowed: boolean; retryAfterSec: number }
 // reCAPTCHA Enterprise assessment. Project id is taken from the Google Cloud
 // console (public, non-secret); only the API key lives in the environment.
 const RECAPTCHA_PROJECT = 'personal-website-1783424992246';
-const RECAPTCHA_ACTION = 'submit';
 
 async function verifyRecaptcha(token: string): Promise<boolean> {
   const apiKey = process.env.RECAPTCHA_ENTERPRISE_API_KEY;
@@ -134,6 +134,13 @@ export async function POST(request: NextRequest) {
   const { name, email, message, phoneNumber, isAgreeingToTerms, recaptchaToken } =
     body;
 
+  if (!name || !email || !message || !isAgreeingToTerms || !recaptchaToken) {
+    return NextResponse.json(
+      { error: 'Missing required fields' },
+      { status: 400 }
+    );
+  }
+
   let isCaptchaValid: boolean;
   try {
     isCaptchaValid = await verifyRecaptcha(recaptchaToken);
@@ -147,13 +154,6 @@ export async function POST(request: NextRequest) {
   if (!isCaptchaValid) {
     return NextResponse.json(
       { error: 'reCAPTCHA verification failed' },
-      { status: 400 }
-    );
-  }
-
-  if (!name || !email || !message || !isAgreeingToTerms) {
-    return NextResponse.json(
-      { error: 'Missing required fields' },
       { status: 400 }
     );
   }

--- a/components/common/SocialRow.tsx
+++ b/components/common/SocialRow.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 const SocialRow: React.FC<React.PropsWithChildren> = ({ children }) => {
   return (
     <div className="w-[80%] m-auto sm:w-5/12">
-      <ul className="flex justify-between items-center w-[100%] list-none m-auto">
+      <ul className="flex justify-center items-center gap-12 sm:gap-16 w-[100%] list-none m-auto">
         {children}
       </ul>
     </div>

--- a/components/forms/ContactForm.tsx
+++ b/components/forms/ContactForm.tsx
@@ -6,6 +6,7 @@ import { TextInput, TextArea, FormButton, FormCheckbox, Alert } from '@/componen
 import submitFormValues from '@/utils/submitForm';
 import Script from 'next/script';
 import { FormValues } from '@/types';
+import { RECAPTCHA_ACTION } from '@/constants/recaptcha';
 
 const ContactForm: React.FC = () => {
   const [showAlert, setShowAlert] = React.useState(false);
@@ -42,11 +43,13 @@ const ContactForm: React.FC = () => {
       return;
     }
 
-    // Promise keeps RHF's isSubmitting true across the detached grecaptcha.ready callback.
+    // Promise keeps RHF's isSubmitting true across the detached grecaptcha.enterprise.ready callback.
     return new Promise<void>((resolve) => {
       grecaptcha.enterprise.ready(async () => {
         try {
-          const token = await grecaptcha.enterprise.execute(siteKey, { action: 'submit' });
+          const token = await grecaptcha.enterprise.execute(siteKey, {
+            action: RECAPTCHA_ACTION,
+          });
           const formData = { ...data, recaptchaToken: token };
           await submitFormValues(formData);
           setShowAlert(true);

--- a/components/forms/ContactForm.tsx
+++ b/components/forms/ContactForm.tsx
@@ -35,7 +35,7 @@ const ContactForm: React.FC = () => {
   const onSubmit: SubmitHandler<FormValues> = (data) => {
     const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY ?? '';
 
-    if (typeof grecaptcha === 'undefined') {
+    if (typeof grecaptcha === 'undefined' || !grecaptcha.enterprise) {
       setAlertType('error');
       setShowAlert(true);
       setTimeout(() => setShowAlert(false), 5000);
@@ -44,9 +44,9 @@ const ContactForm: React.FC = () => {
 
     // Promise keeps RHF's isSubmitting true across the detached grecaptcha.ready callback.
     return new Promise<void>((resolve) => {
-      grecaptcha.ready(async () => {
+      grecaptcha.enterprise.ready(async () => {
         try {
-          const token = await grecaptcha.execute(siteKey, { action: 'submit' });
+          const token = await grecaptcha.enterprise.execute(siteKey, { action: 'submit' });
           const formData = { ...data, recaptchaToken: token };
           await submitFormValues(formData);
           setShowAlert(true);
@@ -82,7 +82,7 @@ const ContactForm: React.FC = () => {
   return (
     <>
       <Script
-        src={`https://www.google.com/recaptcha/api.js?render=${process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}`}
+        src={`https://www.google.com/recaptcha/enterprise.js?render=${process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}`}
       />
       <form
         className="flex flex-col gap-8 border border-gray-800/20 dark:border-white/20 rounded-2xl shadow-lg p-8 relative"

--- a/constants/recaptcha.ts
+++ b/constants/recaptcha.ts
@@ -1,0 +1,3 @@
+// Shared reCAPTCHA action name — the client executes with this action and the
+// server asserts the assessment's action matches. Both sides must agree.
+export const RECAPTCHA_ACTION = 'submit';

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,20 +1,10 @@
-interface ReCaptchaV2 {
-  render(
-    container: string | HTMLElement,
-    parameters: ReCaptchaV2.Parameters
-  ): number;
-  reset(widgetId?: number): void;
-  getResponse(widgetId?: number): string;
-  execute(widgetId?: number, parameters?: { action: string }): Promise<string>;
-}
-
 interface ReCaptchaV3 {
   ready(callback: () => void): void;
   execute(siteKey: string, options: { action: string }): Promise<string>;
 }
 
 declare global {
-  var grecaptcha: ReCaptchaV2 & ReCaptchaV3 & { enterprise: ReCaptchaV3 };
+  var grecaptcha: { enterprise: ReCaptchaV3 };
 }
 
 export {};

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -14,7 +14,7 @@ interface ReCaptchaV3 {
 }
 
 declare global {
-  var grecaptcha: ReCaptchaV2 & ReCaptchaV3;
+  var grecaptcha: ReCaptchaV2 & ReCaptchaV3 & { enterprise: ReCaptchaV3 };
 }
 
 export {};


### PR DESCRIPTION
Two contact-page fixes.

**reCAPTCHA now verifies against Enterprise.** The site key in Google's console is a reCAPTCHA **Enterprise** key, but the form ran the *classic* v3 flow — `api.js` + `grecaptcha.execute()` on the client and `siteverify` on the server. Enterprise tokens can't be validated that way (there's no classic secret), so tokens were generated but never verified, which is why Google reported "unprotected events." This switches the client to `enterprise.js` + `grecaptcha.enterprise.execute()` and the server to the Enterprise **Assessments API** (`recaptchaenterprise.googleapis.com/.../assessments`), checking `tokenProperties.valid`, matching `action`, and `score >= 0.5`.

Requires `RECAPTCHA_ENTERPRISE_API_KEY` in the environment (set in Vercel). The project id is read from the console URL and hardcoded (public, non-secret); the old `RECAPTCHA_SITE_SECRET` is no longer used.

**Social links no longer spread edge-to-edge.** After Instagram/SoundCloud were removed, `justify-between` pushed the two remaining icons to opposite ends. Now centered with a gap, robust for any icon count.

`yarn lint` and `yarn build` pass. Live verification of the Assessments call happens on deploy, once the API key is present.