### PR TITLE
feat: AI-discoverability enrichment, glass alert, and iOS scroll-stage fixes

### DIFF
--- a/components/common/JsonLd.tsx
+++ b/components/common/JsonLd.tsx
@@ -3,11 +3,15 @@ export default function JsonLd() {
     '@type': 'Person',
     '@id': 'https://maxgertzen.com/#person',
     name: 'Max Gertzen',
-    jobTitle: 'Senior Full-Stack Engineer',
+    jobTitle: 'Senior Full-Stack Engineer, AI Integration',
+    description:
+      'Senior full-stack engineer specializing in AI integration — LLM apps, agent systems, and edge infrastructure in TypeScript, React, Node, and .NET. Works remotely, worldwide, and is location-flexible for senior and contract engagements.',
+    image: 'https://maxgertzen.com/opengraph-image',
     url: 'https://maxgertzen.com',
     sameAs: [
       'https://github.com/maxgertzen',
       'https://www.linkedin.com/in/maxgertzen/',
+      'https://theorg.com/org/chargeafter/org-chart/max-gertzen',
     ],
     knowsAbout: [
       'AI Integration',
@@ -46,8 +50,7 @@ export default function JsonLd() {
         '@type': 'Occupation',
         name: 'Senior Full-Stack Engineer',
         description:
-          'Front-end and back-end development for lender integrations on a multi-lender embedded/POS consumer financing platform. Played a key engineering role in an Angular to React migration; set up the NX monorepo and module-federation micro-frontend architecture now used across 30+ lender integrations. Builds LLM and agent systems on the OpenAI and Anthropic APIs.',
-        occupationLocation: { '@type': 'Country', name: 'Thailand' },
+          'Front-end and back-end development for lender integrations on a multi-lender embedded/POS consumer financing platform. Played a key engineering role in an Angular to React migration; set up the NX monorepo and module-federation micro-frontend architecture now used across 30+ lender integrations. Builds LLM and agent systems on the OpenAI and Anthropic APIs. Works remotely and is location-flexible.',
         skills:
           'React, NX, Module Federation, TypeScript, OpenAI API, Anthropic API, LLM Integration, .NET, C#, MongoDB, Azure, GCP, Docker',
       },

--- a/components/common/ScrollStage.tsx
+++ b/components/common/ScrollStage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 // warm→cool crossfade as a fraction of total scroll (ambient, stays global)
 const COOL_START = 0.38;
@@ -8,56 +8,276 @@ const COOL_RANGE = 0.3;
 // the sun completes its rise this far through the hero, so it always crests
 // within the hero regardless of document height (mobile docs are proportionally taller)
 const SUN_HERO_FRACTION = 0.55;
+// horizon sits this far down the (frozen) viewport
+const HORIZON_FRACTION = 0.6;
+// hero scroll cue fades once the page has scrolled past this
+const CUE_FADE_PX = 48;
+// iOS toolbar collapse changes innerHeight by ~60-120px; only a larger height
+// change (real window resize) re-anchors the stage
+const HEIGHT_REMEASURE_PX = 200;
+// canvas extends below the frozen viewport so iOS toolbar collapse (which grows
+// the fixed stage) never reveals unpainted area
+const CANVAS_SLACK = 0.25;
+
+// ---- grid projection tuning ----
+const FOCAL = 320; // perspective focal length
+const CAM_H_MIN = 105; // camera height at scroll start — higher POV opens the row spacing near the horizon
+const CAM_H_MAX = 215; // camera height at scroll end (plane opens up further)
+const Z_NEAR = 60;
+const ROW_SPACING = 140; // world units between horizontal lines
+const COL_SPACING = 96; // world units between vertical lines
+// depth at which the vertical fan must still cover the full viewport width
+// (columns are counted from this so wide screens don't run out of lines)
+const COL_COVER_Z = 2800;
+const WARM_TRAVEL_ROWS = 6; // rows of travel toward the viewer over the full scroll
+const COOL_SPACING_RATIO = 0.82; // cool grid is denser than the warm grid
+const COOL_TRAVEL_ROWS = -3; // cool grid recedes
+
+type Palette = { h: string; v: string; hAlpha: number; vAlpha: number };
+
+// lineGlow: neon halo stroke alpha — reads as glow on dark, as a blurry smear on
+// a light background, so light theme draws clean thin lines only.
+const PALETTES: Record<
+  string,
+  { warm: Palette; cool: Palette; glow: string; glowAlpha: number; lineGlow: number }
+> = {
+  dark: {
+    warm: { h: '255, 45, 149', v: '0, 229, 255', hAlpha: 0.85, vAlpha: 0.7 },
+    cool: { h: '96, 165, 250', v: '96, 165, 250', hAlpha: 0.6, vAlpha: 0.6 },
+    glow: '255, 170, 90',
+    glowAlpha: 0.3,
+    lineGlow: 0.28,
+  },
+  light: {
+    warm: { h: '255, 90, 120', v: '255, 140, 60', hAlpha: 0.55, vAlpha: 0.5 },
+    cool: { h: '37, 99, 235', v: '37, 99, 235', hAlpha: 0.4, vAlpha: 0.4 },
+    glow: '255, 143, 94',
+    glowAlpha: 0.12,
+    lineGlow: 0,
+  },
+};
 
 export default function ScrollStage() {
+  const stageRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
   useEffect(() => {
+    const stage = stageRef.current;
+    const canvas = canvasRef.current;
+    if (!stage || !canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
     const root = document.documentElement;
     const clamp = (v: number) => Math.min(1, Math.max(0, v));
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      root.style.setProperty('--g', '0');
-      root.style.setProperty('--sun', '0');
-      root.style.setProperty('--cool', '0');
-      return;
-    }
+    const prev: Record<string, string> = {};
+    const set = (el: HTMLElement, name: string, value: string) => {
+      if (prev[name] !== value) {
+        el.style.setProperty(name, value);
+        prev[name] = value;
+      }
+    };
 
-    let sunMax = 0;
-    let ticking = false;
-    let prevG = -1;
-    let prevSun = -1;
-    let prevCool = -1;
-
-    // Frozen scroll denominator: on iOS the URL bar collapses on first scroll,
-    // changing window.innerHeight (and, via any vh-sized content, scrollHeight),
-    // which would move the progress denominator and make the stage jump. Cache
-    // the whole denominator and refresh only on width/orientation change.
+    // Frozen geometry: on iOS the URL bar collapses on first scroll, changing
+    // both window.innerHeight and the height of the fixed stage (inset: 0).
+    // Anything derived from the live viewport therefore slides at scroll-start.
+    // Freeze the scroll denominator, the positional anchor (--stage-hz in px),
+    // and the canvas size at load; refresh only on width/orientation change or
+    // a real window resize — never on toolbar-sized height changes.
     let vw = window.innerWidth;
+    let vh = window.innerHeight;
     let maxScroll = 1;
     let sunEnd = 1;
+    let hzPx = Math.round(vh * HORIZON_FRACTION);
+    let dpr = 1;
+
     const measure = () => {
       maxScroll = Math.max(1, root.scrollHeight - window.innerHeight);
       const hero = document.getElementById('hero');
       sunEnd = Math.max(1, (hero?.offsetHeight ?? window.innerHeight) * SUN_HERO_FRACTION);
+      hzPx = Math.round(window.innerHeight * HORIZON_FRACTION);
+      set(stage, '--stage-hz', `${hzPx}px`);
+      set(stage, '--stage-vh', `${window.innerHeight}px`);
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const cssW = window.innerWidth;
+      const cssH = Math.round(window.innerHeight * (1 + CANVAS_SLACK));
+      canvas.style.width = `${cssW}px`;
+      canvas.style.height = `${cssH}px`;
+      canvas.width = Math.round(cssW * dpr);
+      canvas.height = Math.round(cssH * dpr);
     };
+
+    // ---- canvas grid: strokes into one viewport-sized buffer per frame.
+    // No DOM layer, no compositor tiles, no re-rasterization — the whole class
+    // of iOS blank-tile/eviction artifacts cannot occur.
+    // The ground plane has NO far cutoff and NO drawn horizon line: rows are
+    // drawn until they converge sub-pixel into the horizon, fading out with a
+    // crowding fade so the dissolve itself reads as the horizon; verticals fan
+    // out of the true vanishing line. (An explicit line would float isolated
+    // above the faded rows — see the note at the draw() call site.) ----
+    const drawPass = (
+      g: number,
+      alpha: number,
+      p: Palette,
+      spacing: number,
+      travelRows: number,
+      lineGlow: number
+    ) => {
+      const w = canvas.width / dpr;
+      const h = canvas.height / dpr;
+      const hz = hzPx;
+      const cx = w / 2;
+      const camH = CAM_H_MIN + (CAM_H_MAX - CAM_H_MIN) * g;
+
+      // vertical lines: rays from the vanishing line at the horizon through
+      // their near-plane positions, fading in just below the horizon so the
+      // convergence point never becomes a hot cluster
+      const yNear = hz + (camH * FOCAL) / Z_NEAR;
+      const vGrad = ctx.createLinearGradient(0, hz, 0, hz + 24);
+      vGrad.addColorStop(0, `rgba(${p.v}, 0)`);
+      vGrad.addColorStop(1, `rgba(${p.v}, ${alpha * p.vAlpha})`);
+      ctx.strokeStyle = vGrad;
+      ctx.lineWidth = 1.6;
+      ctx.beginPath();
+      const tEdge = (h - hz) / (yNear - hz);
+      const cols = Math.min(120, Math.ceil((w / 2) * COL_COVER_Z / (FOCAL * COL_SPACING)));
+      for (let j = -cols; j <= cols; j++) {
+        const xNear = cx + (j * COL_SPACING * FOCAL) / Z_NEAR;
+        ctx.moveTo(cx, hz);
+        ctx.lineTo(cx + (xNear - cx) * tEdge, h);
+      }
+      ctx.stroke();
+
+      // horizontal rows: from the near plane toward the horizon until they
+      // converge sub-pixel into it, FADING with distance (screen-space depth
+      // fade + crowding fade) so rows dissolve gently as they approach the
+      // horizon rather than stacking into a bright band
+      const phase = (((g * travelRows) % 1) + 1) % 1;
+      let yPrevRow = Number.POSITIVE_INFINITY;
+      for (let k = 0; k < 400; k++) {
+        const z = Z_NEAR + (k + 1 - phase) * spacing;
+        const y = hz + (camH * FOCAL) / z;
+        if (y - hz < 0.6) break;
+        if (y > h) {
+          yPrevRow = y;
+          continue;
+        }
+        const gap = yPrevRow - y;
+        yPrevRow = y;
+        if (gap < 0.35) break; // remaining rows are sub-pixel and faded out
+        // screen-space depth: 1 at the near edge, 0 at the horizon
+        const t = (y - hz) / (h - hz);
+        // crowding fade: rows dim as they pack tighter toward the horizon
+        const crowd = Math.min(1, gap / 2.2);
+        const a = alpha * p.hAlpha * (0.08 + 0.92 * Math.pow(t, 0.85)) * crowd;
+        if (a < 0.015) continue;
+        ctx.strokeStyle = `rgba(${p.h}, ${a})`;
+        const wLine = 1 + t * 1.6;
+        if (lineGlow > 0 && a > 0.04) {
+          ctx.lineWidth = wLine + 2.5;
+          ctx.globalAlpha = lineGlow;
+          ctx.beginPath();
+          ctx.moveTo(0, y);
+          ctx.lineTo(w, y);
+          ctx.stroke();
+          ctx.globalAlpha = 1;
+        }
+        ctx.lineWidth = wLine;
+        ctx.beginPath();
+        ctx.moveTo(0, y);
+        ctx.lineTo(w, y);
+        ctx.stroke();
+      }
+    };
+
+    let lastKey = '';
+    const draw = (g: number, cool: number, sun: number) => {
+      const dark = root.classList.contains('dark');
+      const key = `${g.toFixed(4)}|${cool.toFixed(4)}|${sun.toFixed(4)}|${dark}|${canvas.width}x${canvas.height}`;
+      if (key === lastKey) return;
+      lastKey = key;
+      const pal = PALETTES[dark ? 'dark' : 'light'];
+      const w = canvas.width / dpr;
+      const h = canvas.height / dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, w, h);
+
+      // sunlight reflected on the grid: an elliptical pool spreading down from
+      // below the sun, tracking the sun's rise and fading out in the cool phase
+      const reflect = sun * (1 - cool);
+      if (reflect > 0.01) {
+        ctx.save();
+        ctx.translate(w / 2, hzPx);
+        ctx.scale(1, 0.45);
+        const pool = ctx.createRadialGradient(0, 0, 0, 0, 0, w * 0.55);
+        pool.addColorStop(0, `rgba(${pal.glow}, ${pal.glowAlpha * reflect})`);
+        pool.addColorStop(0.5, `rgba(${pal.warm.h}, ${0.4 * pal.glowAlpha * reflect})`);
+        pool.addColorStop(1, `rgba(${pal.warm.h}, 0)`);
+        ctx.fillStyle = pool;
+        ctx.fillRect(-w / 2, 0, w, (h - hzPx) / 0.45);
+        ctx.restore();
+      }
+
+      // NO explicit horizon line: with the distance fade, the grid dissolving
+      // into the sky IS the horizon. A drawn line would float isolated above the
+      // faded rows — do not add one.
+      if (cool < 1)
+        drawPass(g, (1 - cool) * 0.95, pal.warm, ROW_SPACING, WARM_TRAVEL_ROWS, pal.lineGlow);
+      if (cool > 0)
+        drawPass(g, cool * 0.9, pal.cool, ROW_SPACING * COOL_SPACING_RATIO, COOL_TRAVEL_ROWS, pal.lineGlow);
+    };
+
     measure();
+
+    // re-measure only on a real width/orientation change or a large height
+    // change — never on iOS toolbar-sized height deltas (which must not move
+    // the frozen anchors)
+    const shouldRemeasure = () =>
+      window.innerWidth !== vw || Math.abs(window.innerHeight - vh) > HEIGHT_REMEASURE_PX;
+
+    if (reducedMotion) {
+      set(stage, '--g', '0');
+      set(stage, '--sun', '0');
+      set(stage, '--cool', '0');
+      const redraw = () => draw(0, 0, 0);
+      redraw();
+      const onStaticResize = () => {
+        if (!shouldRemeasure()) return;
+        vw = window.innerWidth;
+        vh = window.innerHeight;
+        measure(); // resizes (and clears) the canvas, so repaint the static grid
+        redraw();
+      };
+      // track theme + viewport so the static grid stays correct
+      const themeObserver = new MutationObserver(redraw);
+      themeObserver.observe(root, { attributes: true, attributeFilter: ['class'] });
+      window.addEventListener('resize', onStaticResize, { passive: true });
+      return () => {
+        themeObserver.disconnect();
+        window.removeEventListener('resize', onStaticResize);
+      };
+    }
+
+    let sunMax = 0;
+    let ticking = false;
+    let lastG = 0;
+    let lastCool = 0;
 
     const tick = () => {
       ticking = false;
-      const g = clamp(window.scrollY / maxScroll);
-      sunMax = Math.max(sunMax, clamp(window.scrollY / sunEnd));
+      const y = window.scrollY;
+      const g = clamp(y / maxScroll);
+      sunMax = Math.max(sunMax, clamp(y / sunEnd));
       const cool = clamp((g - COOL_START) / COOL_RANGE);
-      if (g !== prevG) {
-        root.style.setProperty('--g', g.toFixed(4));
-        prevG = g;
-      }
-      if (sunMax !== prevSun) {
-        root.style.setProperty('--sun', sunMax.toFixed(4));
-        prevSun = sunMax;
-      }
-      if (cool !== prevCool) {
-        root.style.setProperty('--cool', cool.toFixed(4));
-        prevCool = cool;
-      }
+      set(stage, '--g', g.toFixed(4));
+      set(stage, '--sun', sunMax.toFixed(4));
+      set(stage, '--cool', cool.toFixed(4));
+      // hero scroll cue: binary flag, flips rarely; its CSS transition smooths it
+      set(root, '--scrolled', y > CUE_FADE_PX ? '1' : '0');
+      lastG = g;
+      lastCool = cool;
+      draw(g, cool, sunMax);
     };
 
     const onScroll = () => {
@@ -68,11 +288,16 @@ export default function ScrollStage() {
     };
 
     const onResize = () => {
-      if (window.innerWidth === vw) return; // ignore iOS toolbar height-only resizes
+      if (!shouldRemeasure()) return; // ignore iOS toolbar resizes
       vw = window.innerWidth;
+      vh = window.innerHeight;
       measure();
       onScroll();
     };
+
+    // theme switch repaints the grid in the new palette (one cheap canvas draw)
+    const themeObserver = new MutationObserver(() => draw(lastG, lastCool, sunMax));
+    themeObserver.observe(root, { attributes: true, attributeFilter: ['class'] });
 
     window.addEventListener('scroll', onScroll, { passive: true });
     window.addEventListener('resize', onResize, { passive: true });
@@ -81,19 +306,19 @@ export default function ScrollStage() {
     return () => {
       window.removeEventListener('scroll', onScroll);
       window.removeEventListener('resize', onResize);
+      themeObserver.disconnect();
     };
   }, []);
 
   return (
-    <div id="scroll-stage" aria-hidden="true">
+    <div id="scroll-stage" ref={stageRef} aria-hidden="true">
       <div className="stage-sky stage-sky--warm" />
       <div className="stage-sky stage-sky--cool" />
       <div className="stage-sunwrap">
+        <div className="stage-sun-glow" />
         <div className="stage-sun" />
       </div>
-      <div className="stage-horizon" />
-      <div className="stage-grid stage-grid--warm" />
-      <div className="stage-grid stage-grid--cool" />
+      <canvas ref={canvasRef} className="stage-grid-canvas" />
       <div className="stage-scan" />
     </div>
   );

--- a/components/common/ScrollStage.tsx
+++ b/components/common/ScrollStage.tsx
@@ -2,11 +2,12 @@
 
 import { useEffect } from 'react';
 
-// scroll-progress (0..1) keyframes: when the sun rises and when warm→cool crossfades
-const SUN_START = 0.08;
-const SUN_RANGE = 0.14;
+// warm→cool crossfade as a fraction of total scroll (ambient, stays global)
 const COOL_START = 0.38;
 const COOL_RANGE = 0.3;
+// the sun completes its rise this far through the hero, so it always crests
+// within the hero regardless of document height (mobile docs are proportionally taller)
+const SUN_HERO_FRACTION = 0.55;
 
 export default function ScrollStage() {
   useEffect(() => {
@@ -26,11 +27,24 @@ export default function ScrollStage() {
     let prevSun = -1;
     let prevCool = -1;
 
+    // Frozen scroll denominator: on iOS the URL bar collapses on first scroll,
+    // changing window.innerHeight (and, via any vh-sized content, scrollHeight),
+    // which would move the progress denominator and make the stage jump. Cache
+    // the whole denominator and refresh only on width/orientation change.
+    let vw = window.innerWidth;
+    let maxScroll = 1;
+    let sunEnd = 1;
+    const measure = () => {
+      maxScroll = Math.max(1, root.scrollHeight - window.innerHeight);
+      const hero = document.getElementById('hero');
+      sunEnd = Math.max(1, (hero?.offsetHeight ?? window.innerHeight) * SUN_HERO_FRACTION);
+    };
+    measure();
+
     const tick = () => {
       ticking = false;
-      const max = root.scrollHeight - window.innerHeight;
-      const g = max > 0 ? clamp(window.scrollY / max) : 0;
-      sunMax = Math.max(sunMax, clamp((g - SUN_START) / SUN_RANGE));
+      const g = clamp(window.scrollY / maxScroll);
+      sunMax = Math.max(sunMax, clamp(window.scrollY / sunEnd));
       const cool = clamp((g - COOL_START) / COOL_RANGE);
       if (g !== prevG) {
         root.style.setProperty('--g', g.toFixed(4));
@@ -53,13 +67,20 @@ export default function ScrollStage() {
       }
     };
 
+    const onResize = () => {
+      if (window.innerWidth === vw) return; // ignore iOS toolbar height-only resizes
+      vw = window.innerWidth;
+      measure();
+      onScroll();
+    };
+
     window.addEventListener('scroll', onScroll, { passive: true });
-    window.addEventListener('resize', onScroll, { passive: true });
+    window.addEventListener('resize', onResize, { passive: true });
     tick();
 
     return () => {
       window.removeEventListener('scroll', onScroll);
-      window.removeEventListener('resize', onScroll);
+      window.removeEventListener('resize', onResize);
     };
   }, []);
 

--- a/components/ui/Alert.tsx
+++ b/components/ui/Alert.tsx
@@ -7,20 +7,30 @@ interface AlertProps {
   onClose: () => void;
 }
 
-const variantStyles = {
-  success: 'bg-green-100 border-green-500 text-green-700',
-  error: 'bg-red-100 border-red-500 text-red-700',
+const tintClass: Record<AlertProps['variant'], string> = {
+  success: 'glass-alert__tint--success',
+  error: 'glass-alert__tint--error',
+};
+
+const textClass: Record<AlertProps['variant'], string> = {
+  success: 'text-emerald-950 dark:text-emerald-50',
+  error: 'text-rose-950 dark:text-rose-50',
 };
 
 const Alert: React.FC<AlertProps> = ({ variant, title, children, onClose }) => {
   return (
     <div
-      className={`${variantStyles[variant]} border-l-4 rounded-2xl p-4 animate__animated animate__fadeInUp absolute top-0 left-0 right-0 z-40`}
+      className="glass glass-alert absolute top-0 left-0 right-0 z-40 cursor-pointer"
       role="alert"
       onClick={onClose}
     >
-      <p className="font-bold">{title}</p>
-      {children}
+      <div className="glass__effect" />
+      <div className={`glass__tint ${tintClass[variant]}`} />
+      <div className="glass__shine" />
+      <div className={`glass-alert__content ${textClass[variant]}`}>
+        <p className="font-bold">{title}</p>
+        <div className="text-sm">{children}</div>
+      </div>
     </div>
   );
 };

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,8 +1,8 @@
 # Max Gertzen
 
-> Senior full-stack engineer specializing in AI integration — LLM apps, agent systems, and edge infrastructure. Builds in TypeScript, React, Node, and .NET. Available for senior and contract work through Greatwhale Solutions.
+> Senior full-stack engineer specializing in AI integration — LLM apps, agent systems, and edge infrastructure. Builds in TypeScript, React, Node, and .NET. Available remotely, worldwide, for senior and contract work through Greatwhale Solutions.
 
-Max Gertzen is a senior software engineer focused on AI-integrated product development: LLM applications, vision, and autonomous agents built on the OpenAI and Anthropic APIs. He designs the foundations teams build on and moves easily between codebases, clients, and countries. Trilingual (English, Russian, Hebrew).
+Max Gertzen is a senior software engineer focused on AI-integrated product development: LLM applications, vision, and autonomous agents built on the OpenAI and Anthropic APIs. He designs the foundations teams build on and ships complete products end to end. He works remotely and is location-flexible, moving easily between codebases, clients, and countries. Trilingual (English, Russian, Hebrew).
 
 ## About
 
@@ -10,7 +10,22 @@ Max Gertzen is a senior software engineer focused on AI-integrated product devel
 - Core stack: TypeScript, React, Next.js, Node.js, C#/.NET
 - AI: OpenAI API, Anthropic API, LLM integration, AI agents, prompt engineering
 - Architecture: NX monorepo, module federation micro-frontends, Cloudflare Workers, Docker, MongoDB
-- Company: Greatwhale Solutions Ltd (independent contracting)
+- Company: Greatwhale Solutions Ltd (independent contracting, Hong Kong registered)
+- Availability: Remote, worldwide — location-flexible for senior and contract engagements
+
+## Experience
+
+- Senior Full-Stack Engineer at ChargeAfter (2021–present) — a multi-lender embedded/POS consumer-financing platform for the US market.
+  - Played a key engineering role migrating a legacy Angular monorepo to an NX-modular React architecture with module-federation micro-frontends.
+  - Authored the engineering guidelines now used by 4 teams across 30+ lender integrations, and shipped 20+ lender integrations end to end.
+  - Served as technical anchor for a team of ~10 engineers; extended backend services in .NET/C#.
+- Founder, Greatwhale Solutions Ltd — independent contracting for AI-integration and full-stack product work.
+- Selected work: provider-agnostic LLM classification libraries, multi-agent systems, and edge-deployed full-stack apps on Cloudflare Workers.
+
+## Education
+
+- Full-Stack Development Bootcamp — WeCode (Reichman University), 2021
+- Full-Stack Development Bootcamp — Elevation, 2018
 
 ## Links
 
@@ -21,4 +36,4 @@ Max Gertzen is a senior software engineer focused on AI-integrated product devel
 
 ## Contact
 
-Reach out via the contact form at https://maxgertzen.com for senior engineering roles or contract engagements.
+Reach out via the contact form at https://maxgertzen.com for senior engineering roles or contract engagements. Available remotely, worldwide.

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -149,16 +149,25 @@
 }
 
 
+/* The chevron pulse animates border-color (a plain repaint of a 32px element)
+   instead of opacity, which WebKit would force-composite: with no GPU layer per
+   chevron there is nothing to flash or corrupt on theme switch or scroll. The
+   implicit keyframe end resolves to the themed border color. */
 .arrow {
 	display: block;
 	width: 2rem;
 	height: 2rem;
 	margin: 0 0 3px 5px;
-	animation: mouse-scroll 1s infinite;
-	-webkit-animation: mouse-scroll 1s infinite;
-	-moz-animation: mouse-scroll 1s infinite;
+	animation: arrow-pulse 1s infinite;
 	border-right: 2px solid #000;
 	border-bottom: 2px solid #000;
+}
+
+@keyframes arrow-pulse {
+	from {
+		border-right-color: transparent;
+		border-bottom-color: transparent;
+	}
 }
 
 .arrow-down {
@@ -279,10 +288,7 @@
 :root {
   --stage-amber: hsl(var(--color-brand));
   --stage-magenta: #ff2d95;
-  --stage-hz: 60%;
-  --g: 0;
-  --sun: 0;
-  --cool: 0;
+  --scrolled: 0;
 }
 
 html {
@@ -301,17 +307,33 @@ main {
   z-index: 1;
 }
 
+/* The stage is fixed to the LIVE viewport (inset: 0) — on iOS the toolbar
+   collapse grows it at scroll-start. Everything positional inside is therefore
+   anchored to --stage-hz, which JS freezes as a PX value at load (fallback 60%),
+   so nothing slides when the stage itself resizes. Scroll only ever animates
+   transform and opacity (compositor-only); no property that triggers paint
+   (filter/background-position) is driven per-frame. */
 #scroll-stage {
   position: fixed;
   inset: 0;
   z-index: 0;
   overflow: hidden;
   pointer-events: none;
+  --stage-hz: 60%; /* horizon Y; JS freezes this as px (fallback: 60% of viewport) */
+  --stage-vh: 100%; /* frozen viewport height; JS freezes as px (fallback: 100% of stage) */
+  --g: 0;
+  --sun: 0;
+  --cool: 0;
 }
 
+/* Sky height is pinned to the frozen viewport plus slack to cover iOS toolbar
+   growth, so the gradient never stretches mid-scroll. */
 .stage-sky {
   position: absolute;
-  inset: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: calc(var(--stage-vh) + 20svh);
 }
 
 .stage-sky--warm {
@@ -324,45 +346,22 @@ main {
   opacity: var(--cool);
 }
 
-.stage-grid {
+/* The grid is drawn on a canvas (see ScrollStage.tsx): one viewport-sized
+   buffer, no DOM layer, no compositor tiles. A perspective-transformed DOM
+   layer here checkerboards on iOS (blank 512px tiles under GPU memory
+   pressure) — keep it canvas. JS sizes it to the frozen viewport + slack. */
+.stage-grid-canvas {
   position: absolute;
-  left: -55%;
-  right: -55%;
-  top: var(--stage-hz);
-  height: 130vh;
-  transform-origin: center top;
-  transform: perspective(340px) rotateX(calc(76deg - var(--g) * 52deg));
-}
-
-.stage-grid--warm {
-  background-image: linear-gradient(rgba(255, 45, 149, 0.85) 2px, transparent 2px),
-    linear-gradient(90deg, rgba(0, 229, 255, 0.7) 2px, transparent 2px);
-  background-size: 66px 66px;
-  background-position: 0 calc(var(--g) * -520px);
-  opacity: calc((1 - var(--cool)) * 0.95);
-  filter: drop-shadow(0 0 7px rgba(255, 45, 149, 0.5));
-}
-
-.stage-grid--cool {
-  background-image: linear-gradient(rgba(96, 165, 250, 0.6) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(96, 165, 250, 0.6) 1px, transparent 1px);
-  background-size: 54px 54px;
-  background-position: 0 calc(var(--g) * 280px);
-  opacity: calc(var(--cool) * 0.9);
-}
-
-.stage-horizon {
-  position: absolute;
+  top: 0;
   left: 0;
-  right: 0;
-  top: var(--stage-hz);
-  height: 3px;
-  z-index: 2;
-  background: linear-gradient(90deg, transparent, hsl(var(--color-brand) / 0.95), var(--stage-magenta), transparent);
-  filter: blur(calc(1px + var(--sun) * 7px));
-  opacity: calc((1 - var(--cool)) * (0.4 + var(--sun) * 0.6));
 }
 
+/* The horizon is where the canvas grid dissolves — there is no separate
+   horizon element (see ScrollStage.tsx). --sun-y is the shared vertical
+   position for the sun and its glow: it rises with --sun, then sinks back
+   below the horizon with --cool so the warm→cool morph reads as a sunset.
+   The sunwrap clips at the horizon (overflow:hidden), which is what makes the
+   sun visibly set. The % term resolves against each child's own height. */
 .stage-sunwrap {
   position: absolute;
   left: 0;
@@ -371,6 +370,9 @@ main {
   height: var(--stage-hz);
   overflow: hidden;
   z-index: 1;
+  --sun-y: calc(
+    (1 - var(--sun)) * 145% - var(--sun) * 11vh + var(--cool) * 145% + var(--cool) * 11vh
+  );
 }
 
 .stage-sun {
@@ -380,12 +382,26 @@ main {
   width: min(30vw, 220px);
   aspect-ratio: 1;
   border-radius: 50%;
-  opacity: calc(1 - var(--cool));
-  transform: translateX(-50%) translateY(calc((1 - var(--sun)) * 145% - var(--sun) * 11vh));
+  opacity: calc(1 - var(--cool) * 0.4); /* only dims slightly while setting — the clip hides it */
+  transform: translateX(-50%) translateY(var(--sun-y));
+  will-change: transform;
   background: linear-gradient(180deg, #ffe08a, var(--stage-amber) 42%, var(--stage-magenta));
   -webkit-mask-image: repeating-linear-gradient(180deg, #000 0 13px, transparent 13px 19px);
   mask-image: repeating-linear-gradient(180deg, #000 0 13px, transparent 13px 19px);
-  filter: drop-shadow(0 0 calc(16px + var(--sun) * 54px) hsl(var(--color-brand) / calc(0.12 + var(--sun) * 0.55)));
+}
+
+/* Sun glow as its own compositor-only layer — only opacity + transform animate
+   (a per-frame filter/drop-shadow here would repaint every frame). */
+.stage-sun-glow {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: min(30vw, 220px);
+  aspect-ratio: 1;
+  background: radial-gradient(circle, hsl(var(--color-brand) / 0.5) 0%, hsl(var(--color-brand) / 0.18) 45%, transparent 70%);
+  opacity: calc((0.18 + var(--sun) * 0.82) * (1 - var(--cool)));
+  transform: translateX(-50%) translateY(var(--sun-y)) scale(calc(1.3 + var(--sun) * 0.8));
+  will-change: transform;
 }
 
 .stage-scan {
@@ -396,21 +412,8 @@ main {
   opacity: calc((1 - var(--cool)) * 0.7);
 }
 
-/* Mobile: iOS evicts the backing store of the oversized grid layer (3D transform
-   + drop-shadow + blend) under memory pressure, so the grid blinks out mid-scroll.
-   Shrink the painted area and cut the expensive effects; desktop is untouched. */
+/* Mobile: cheaper scanlines (blend modes are costly on iOS) */
 @media (max-width: 768px) {
-  .stage-grid {
-    left: -20%;
-    right: -20%;
-    height: 100svh;
-    backface-visibility: hidden;
-  }
-
-  .stage-grid--warm {
-    filter: none;
-  }
-
   .stage-scan {
     mix-blend-mode: normal;
     opacity: calc((1 - var(--cool)) * 0.28);
@@ -550,19 +553,10 @@ html:not(.dark) .stage-sun {
   background: linear-gradient(180deg, #ffcf87, #ff8f5e 46%, #ff5f86);
 }
 
-html:not(.dark) .stage-horizon {
-  background: linear-gradient(90deg, transparent, rgba(255, 140, 60, 0.9), #ff5f86, transparent);
-}
-
-html:not(.dark) .stage-grid--warm {
-  background-image: linear-gradient(rgba(255, 90, 120, 0.55) 2px, transparent 2px),
-    linear-gradient(90deg, rgba(255, 140, 60, 0.5) 2px, transparent 2px);
-  filter: none;
-}
-
-html:not(.dark) .stage-grid--cool {
-  background-image: linear-gradient(rgba(37, 99, 235, 0.4) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(37, 99, 235, 0.4) 1px, transparent 1px);
+/* light theme: soft daylight — halve the glow blob (full-strength neon reads
+   as smears/washes on a cream background) */
+html:not(.dark) .stage-sun-glow {
+  background: radial-gradient(circle, rgba(255, 143, 94, 0.26) 0%, rgba(255, 143, 94, 0.09) 45%, transparent 70%);
 }
 
 html:not(.dark) .stage-scan {
@@ -717,15 +711,24 @@ html:not(.dark) .glass-alert__tint--error {
   }
 }
 
-/* hero scroll cue fades out as soon as the page scrolls (before the sun rises) */
+/* hero scroll cue fades once the page scrolls; --scrolled is a binary flag set
+   on :root by ScrollStage, smoothed by the transition.
+   Deliberately NO will-change here: a permanently promoted layer over the
+   animated grid holds stale backing-store tiles on iOS — do not add one.
+   Tap-highlight off so a scroll gesture starting on the button doesn't paint
+   iOS's gray highlight square. */
 .stage-scroller-fade {
-  opacity: clamp(0, calc(1 - var(--g) * 12), 1);
+  opacity: calc(1 - var(--scrolled, 0));
   transition: opacity 0.25s linear;
 }
 
+.stage-scroller-fade button {
+  -webkit-tap-highlight-color: transparent;
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .stage-grid,
-  .stage-sun {
+  .stage-sun,
+  .stage-sun-glow {
     transform: none !important;
   }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -617,6 +617,53 @@ html:not(.dark) .glass__shine {
     inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
+/* contact-form alert: liquid-glass card with a semantic colour tint */
+.glass-alert {
+  border-radius: 1rem;
+  box-shadow: 0 10px 34px rgba(0, 0, 0, 0.35);
+  animation: alert-in 0.35s ease-out both;
+}
+
+.glass-alert__content {
+  position: relative;
+  z-index: 3;
+  padding: 0.85rem 1.15rem;
+}
+
+/* tint overrides sit after .glass__tint so equal-specificity source order wins */
+.glass-alert__tint--success {
+  background: rgba(16, 185, 129, 0.34);
+}
+
+.glass-alert__tint--error {
+  background: rgba(255, 45, 149, 0.34);
+}
+
+html:not(.dark) .glass-alert__tint--success {
+  background: rgba(16, 185, 129, 0.26);
+}
+
+html:not(.dark) .glass-alert__tint--error {
+  background: rgba(244, 63, 94, 0.22);
+}
+
+@keyframes alert-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glass-alert {
+    animation: none;
+  }
+}
+
 /* hero scroll cue fades out as soon as the page scrolls (before the sun rises) */
 .stage-scroller-fade {
   opacity: clamp(0, calc(1 - var(--g) * 12), 1);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -396,6 +396,27 @@ main {
   opacity: calc((1 - var(--cool)) * 0.7);
 }
 
+/* Mobile: iOS evicts the backing store of the oversized grid layer (3D transform
+   + drop-shadow + blend) under memory pressure, so the grid blinks out mid-scroll.
+   Shrink the painted area and cut the expensive effects; desktop is untouched. */
+@media (max-width: 768px) {
+  .stage-grid {
+    left: -20%;
+    right: -20%;
+    height: 100svh;
+    backface-visibility: hidden;
+  }
+
+  .stage-grid--warm {
+    filter: none;
+  }
+
+  .stage-scan {
+    mix-blend-mode: normal;
+    opacity: calc((1 - var(--cool)) * 0.28);
+  }
+}
+
 /* word emphasis (wrap-safe, draws on when in view) */
 .emph {
   position: relative;
@@ -463,6 +484,14 @@ main {
   white-space: nowrap;
   will-change: transform;
   user-select: none;
+}
+
+/* drop the permanent layer promotion on mobile: one fewer composited layer
+   competing for iOS memory next to the grid (helps the grid stay painted) */
+@media (max-width: 768px) {
+  .mq-track {
+    will-change: auto;
+  }
 }
 
 .mq-chip {
@@ -567,9 +596,19 @@ html:not(.dark) .mq-chip {
   inset: 0;
   z-index: 0;
   border-radius: inherit;
-  -webkit-backdrop-filter: blur(2px) saturate(1.6);
-  backdrop-filter: blur(2px) saturate(1.6);
-  backdrop-filter: url(#glass-distortion) blur(2px) saturate(1.6);
+  /* guaranteed frosted fallback: WebKit/iOS drop SVG-filter backdrops, so a plain
+     blur must win the cascade there. Stronger blur so the frost reads on its own. */
+  -webkit-backdrop-filter: blur(7px) saturate(1.5);
+  backdrop-filter: blur(7px) saturate(1.5);
+}
+
+/* liquid refraction only where SVG-filter backdrops actually render. The Houdini
+   Paint API is Chromium-only, so this gates the distortion to Blink and lets
+   Safari/Firefox keep the plain-blur frost above (degrades safely both ways). */
+@supports (background: paint(id)) {
+  .glass__effect {
+    backdrop-filter: url(#glass-distortion) blur(2px) saturate(1.6);
+  }
 }
 
 .glass__tint {
@@ -609,6 +648,20 @@ html:not(.dark) .glass {
 
 html:not(.dark) .glass__tint {
   background: rgba(255, 255, 255, 0.55);
+}
+
+/* Safari/iOS won't blur a position:fixed backdrop, so the plain-blur frost never
+   materializes there — the sharp stage bleeds through and hurts legibility. Where
+   the SVG refraction is unavailable (non-Chromium), lean on a more opaque tint so
+   the card still reads as frosted glass. Chromium keeps its lighter tint + refraction. */
+@supports not (background: paint(id)) {
+  .glass__tint {
+    background: rgba(16, 16, 28, 0.64);
+  }
+
+  html:not(.dark) .glass__tint {
+    background: rgba(255, 255, 255, 0.74);
+  }
 }
 
 html:not(.dark) .glass__shine {


### PR DESCRIPTION
Bundles the three ready dex tasks into one PR.

## SEO / AI discoverability (`tppqz85t` + `hv47knkc`)
- **llms.txt**: added **Experience** (ChargeAfter — Angular→React NX/module-federation migration, engineering guidelines across **30+ lender integrations**, 20+ shipped, tech anchor for ~10 engineers) and **Education**; states remote/worldwide, **location-flexible** availability. Sourced from the base senior-IC resume.
- **JsonLd**: dropped the `Thailand` `occupationLocation` (read as 'based in Thailand'); added a remote/location-flexible note, `Person` `description` + `image`, `jobTitle` 'Senior Full-Stack Engineer, AI Integration', and a **TheOrg `sameAs`** entry to strengthen entity fusion across profiles.

## Contact form alert (`7idzmcr5`)
- Restyled the submission Alert as **liquid-glass**, reusing the site's `.glass` layers (effect/tint/shine) with a **semantic tint**: emerald=success, magenta/rose=error. Theme-aware in dark and light.
- Added an `alert-in` entrance keyframe (reduced-motion aware).
- Removed dead `animate.css` classes (the library was never imported).

## Verification
- `yarn lint` clean; `yarn build` green (7/7 static pages).
- No 'Thailand' left in source; JSON-LD valid.
- Alert visually verified via Playwright in **both dark and light**, success and error variants.

## Context
Discoverability baseline (2026-07-20): Perplexity cites the site correctly; ChatGPT's entity model is stale/third-party-dominated (retrieval-side, not content). Unbranded discovery remains a long game. Re-test after this deploys.

---

## iOS scroll-morph background fixes (folded in from #46)

Four iOS/WebKit-specific bugs in the fixed scroll-morph "vaporwave stage"; **desktop rendering unchanged** (mobile-scoped `@media` + Chromium-gated refraction). Approved via a research-backed council.

| # | Bug | Fix |
|---|-----|-----|
| **1** | Glass card showed the sharp stage through it on iOS (no blur) | WebKit renders `backdrop-filter: url(#svg)` as a no-op and won't blur a `position:fixed` backdrop. Plain-blur fallback + Chromium-gated SVG refraction via `@supports (background: paint(id))` + more opaque `.glass__tint` in the non-refraction path. |
| **2** | Sun/grid jumped on first swipe | iOS URL-bar collapse changes `window.innerHeight`. Freeze the scroll-progress denominator (cache it; refresh only on width/orientation change). |
| **3** | Sun rose at the wrong section on mobile | Anchor the sun's rise to the **hero's height** (crests ~55% through the hero) instead of a hardcoded global scroll fraction. |
| **4** | Neon grid blinked out mid-scroll on iOS | Backing-store eviction. Mobile `@media`: shrink the layer, drop `drop-shadow`/`mix-blend-mode`, add a compositing stabilizer, drop the marquee's permanent `will-change`. |

**Verified in Playwright WebKit (Safari engine):** frost renders both themes; denominator stable across an `innerHeight` change; sun crests before About; grid effects reduced. **On-device confirmation still recommended** for Fixes 2 & 4 (real iOS toolbar / GPU memory pressure can't be reproduced headless).
