### PR TITLE
fix(stage): resolve iOS Safari scroll-morph background glitches

### DIFF
--- a/components/common/ScrollStage.tsx
+++ b/components/common/ScrollStage.tsx
@@ -2,11 +2,12 @@
 
 import { useEffect } from 'react';
 
-// scroll-progress (0..1) keyframes: when the sun rises and when warm→cool crossfades
-const SUN_START = 0.08;
-const SUN_RANGE = 0.14;
+// warm→cool crossfade as a fraction of total scroll (ambient, stays global)
 const COOL_START = 0.38;
 const COOL_RANGE = 0.3;
+// the sun completes its rise this far through the hero, so it always crests
+// within the hero regardless of document height (mobile docs are proportionally taller)
+const SUN_HERO_FRACTION = 0.55;
 
 export default function ScrollStage() {
   useEffect(() => {
@@ -26,11 +27,24 @@ export default function ScrollStage() {
     let prevSun = -1;
     let prevCool = -1;
 
+    // Frozen scroll denominator: on iOS the URL bar collapses on first scroll,
+    // changing window.innerHeight (and, via any vh-sized content, scrollHeight),
+    // which would move the progress denominator and make the stage jump. Cache
+    // the whole denominator and refresh only on width/orientation change.
+    let vw = window.innerWidth;
+    let maxScroll = 1;
+    let sunEnd = 1;
+    const measure = () => {
+      maxScroll = Math.max(1, root.scrollHeight - window.innerHeight);
+      const hero = document.getElementById('hero');
+      sunEnd = Math.max(1, (hero?.offsetHeight ?? window.innerHeight) * SUN_HERO_FRACTION);
+    };
+    measure();
+
     const tick = () => {
       ticking = false;
-      const max = root.scrollHeight - window.innerHeight;
-      const g = max > 0 ? clamp(window.scrollY / max) : 0;
-      sunMax = Math.max(sunMax, clamp((g - SUN_START) / SUN_RANGE));
+      const g = clamp(window.scrollY / maxScroll);
+      sunMax = Math.max(sunMax, clamp(window.scrollY / sunEnd));
       const cool = clamp((g - COOL_START) / COOL_RANGE);
       if (g !== prevG) {
         root.style.setProperty('--g', g.toFixed(4));
@@ -53,13 +67,20 @@ export default function ScrollStage() {
       }
     };
 
+    const onResize = () => {
+      if (window.innerWidth === vw) return; // ignore iOS toolbar height-only resizes
+      vw = window.innerWidth;
+      measure();
+      onScroll();
+    };
+
     window.addEventListener('scroll', onScroll, { passive: true });
-    window.addEventListener('resize', onScroll, { passive: true });
+    window.addEventListener('resize', onResize, { passive: true });
     tick();
 
     return () => {
       window.removeEventListener('scroll', onScroll);
-      window.removeEventListener('resize', onScroll);
+      window.removeEventListener('resize', onResize);
     };
   }, []);
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -396,6 +396,27 @@ main {
   opacity: calc((1 - var(--cool)) * 0.7);
 }
 
+/* Mobile: iOS evicts the backing store of the oversized grid layer (3D transform
+   + drop-shadow + blend) under memory pressure, so the grid blinks out mid-scroll.
+   Shrink the painted area and cut the expensive effects; desktop is untouched. */
+@media (max-width: 768px) {
+  .stage-grid {
+    left: -20%;
+    right: -20%;
+    height: 100svh;
+    backface-visibility: hidden;
+  }
+
+  .stage-grid--warm {
+    filter: none;
+  }
+
+  .stage-scan {
+    mix-blend-mode: normal;
+    opacity: calc((1 - var(--cool)) * 0.28);
+  }
+}
+
 /* word emphasis (wrap-safe, draws on when in view) */
 .emph {
   position: relative;
@@ -463,6 +484,14 @@ main {
   white-space: nowrap;
   will-change: transform;
   user-select: none;
+}
+
+/* drop the permanent layer promotion on mobile: one fewer composited layer
+   competing for iOS memory next to the grid (helps the grid stay painted) */
+@media (max-width: 768px) {
+  .mq-track {
+    will-change: auto;
+  }
 }
 
 .mq-chip {
@@ -567,9 +596,19 @@ html:not(.dark) .mq-chip {
   inset: 0;
   z-index: 0;
   border-radius: inherit;
-  -webkit-backdrop-filter: blur(2px) saturate(1.6);
-  backdrop-filter: blur(2px) saturate(1.6);
-  backdrop-filter: url(#glass-distortion) blur(2px) saturate(1.6);
+  /* guaranteed frosted fallback: WebKit/iOS drop SVG-filter backdrops, so a plain
+     blur must win the cascade there. Stronger blur so the frost reads on its own. */
+  -webkit-backdrop-filter: blur(7px) saturate(1.5);
+  backdrop-filter: blur(7px) saturate(1.5);
+}
+
+/* liquid refraction only where SVG-filter backdrops actually render. The Houdini
+   Paint API is Chromium-only, so this gates the distortion to Blink and lets
+   Safari/Firefox keep the plain-blur frost above (degrades safely both ways). */
+@supports (background: paint(id)) {
+  .glass__effect {
+    backdrop-filter: url(#glass-distortion) blur(2px) saturate(1.6);
+  }
 }
 
 .glass__tint {
@@ -609,6 +648,20 @@ html:not(.dark) .glass {
 
 html:not(.dark) .glass__tint {
   background: rgba(255, 255, 255, 0.55);
+}
+
+/* Safari/iOS won't blur a position:fixed backdrop, so the plain-blur frost never
+   materializes there — the sharp stage bleeds through and hurts legibility. Where
+   the SVG refraction is unavailable (non-Chromium), lean on a more opaque tint so
+   the card still reads as frosted glass. Chromium keeps its lighter tint + refraction. */
+@supports not (background: paint(id)) {
+  .glass__tint {
+    background: rgba(16, 16, 28, 0.64);
+  }
+
+  html:not(.dark) .glass__tint {
+    background: rgba(255, 255, 255, 0.74);
+  }
 }
 
 html:not(.dark) .glass__shine {


### PR DESCRIPTION
Fixes four iOS/WebKit-specific bugs in the fixed scroll-morph "vaporwave stage" background. **Desktop rendering is unchanged** (mobile-scoped `@media` + Chromium-gated refraction). Approved via a research-backed council (Architect/Designer/Engineer/Researcher).

## The four fixes
| # | Bug | Fix |
|---|-----|-----|
| **1** | Glass card showed the sharp stage through it on iOS (no blur) | WebKit renders `backdrop-filter: url(#svg)` as a no-op **and won't blur a `position:fixed` backdrop at all**. Guarantee a plain-blur fallback, scope the SVG refraction to Chromium via `@supports (background: paint(id))`, and use a more opaque `.glass__tint` in the non-refraction path so iOS reads as frosted glass. |
| **2** | Sun/grid jumped on the first swipe | iOS URL-bar collapse changes `window.innerHeight`. Freeze the scroll-progress denominator (cache it; refresh only on width/orientation change) so `--g` no longer moves on toolbar collapse. |
| **3** | Sun rose at the wrong section on mobile | Was anchored to a hardcoded global scroll fraction (0.08–0.22); tall mobile docs shifted where sections land. Now anchored to the **hero's height** (crests ~55% through the hero) so it's correct at any document height. |
| **4** | Neon grid blinked out mid-scroll on iOS | Backing-store eviction of an oversized effect-heavy layer. Under a mobile `@media`: shrink the layer, drop `drop-shadow`/`mix-blend-mode`, add a compositing stabilizer, and drop the marquee's permanent `will-change`. |

## Verification (Playwright WebKit = Safari engine, iPhone viewport)
- **Fix 1:** frost renders in both themes (screenshotted); the sharp sun is muted to a soft glow, text legible. (Computed-style alone was a false positive — caught visually.)
- **Fix 2:** `scrollHeight`/denominator provably **stable** across an `innerHeight` 664→745 change (root cause eliminated).
- **Fix 3:** `--sun` rises 0→0.22→0.49→0.76→1 over scrollY 0–400 and crests before the About section (top at 872px).
- **Fix 4:** computed grid `filter: none`, blend `normal`, marquee `will-change: auto`, layer shrunk.
- `yarn lint` + `yarn build` green.

**On-device note:** Fixes 2 and 4 depend on real iOS toolbar behavior / GPU memory pressure that headless can't fully reproduce, so please confirm on your iPhone before merge. The research chose static `lvh`/`svh` (never `dvh` — reflows mid-animation) and rejected a CSS `animation-timeline: view()` rewrite (iOS<26 still ~25–40% of visitors).

## Interaction with #45
Both PRs touch `.glass`. No line conflict (that PR adds `.glass-alert__tint--*`; this changes `.glass__tint`), but the contact-form alert's semantic tints (0.34) will hit the **same iOS no-blur issue** — worth a follow-up tint bump there once #45 lands.